### PR TITLE
Fix for premium weapon checkbox (recolour weapons)

### DIFF
--- a/public/javascripts/controllers/SequencerController.js
+++ b/public/javascripts/controllers/SequencerController.js
@@ -415,8 +415,18 @@ yattoApp.controller('SequencerController',
 					w.wi = weapon - 1;
 				}
 
+				// The calculation of the weapon var fails for darklord ("33"),
+				// should be "32" as far as I know
+				// For other heros it seems to work (e.g Jackalope -> "31")
+				if (weapon == 33) {
+					weapon -= 1 ;
+				}
+
+				// execption occrus here for var weapon = 33, DL
+				// since the array is only filled up to 32
 				$scope.current_weapons[weapon].a += 1;
 			});
+
 
 			$scope.recolorWeapons();
 		};


### PR DESCRIPTION
Fix for premium weapon checkbox. 

When you hit the ckeckbox to simulate a premium weapon on a DL (although it is useless) the simulation works properly. As you uncheck the field the slot is still coloured as minWeapon CSS class.

The bug is located in SequencerController.js : 427

As far as I can tell the generation of the weapon variable for the heroToName[weapon] lookup is not correct for dark lord. In this case a '33' is generated which leads to an exception as you try to call: 

```
// length of 32, calling for 33 though ..
$scope.current_weapons[weapon].a += 1;
```

Unfortunately I could not find the cause for the problem. So this is only a hotfix.

Before:
![before](https://cloud.githubusercontent.com/assets/5173254/10619016/9d4fb018-7773-11e5-8d25-eb2b896b7c4c.png)

After:
![after](https://cloud.githubusercontent.com/assets/5173254/10619036/bcc3eac2-7773-11e5-9d85-c0d8a798f102.png)

The bug
