### PR TITLE
Allow loading from .bin files taken directly from iCloud

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -55,8 +55,10 @@ yattoApp.directive("fileread", [function () {
           });
         }
         console.log("lakjsldkjflakjsldf");
-        if (changeEvent.target.files[0].name.split(".").pop() == "adat") {
-          reader.readAsText(changeEvent.target.files[0]);
+        var file = changeEvent.target.files[0];
+        var extension = file.name.split(".").pop();
+        if (extension == "adat" || extension == "bin") {
+          reader.readAsText(file);
         } else {
           // TODO: display error
         }


### PR DESCRIPTION
On a Mac the iCloud save syncs to `~/Library/Mobile\ Documents/iCloud~com~gamehivecorp~taptitans/TT_CloudSave.bin`

So it's really easy to manage backups that way, but the default filename is `TT_CloudSave.bin`. YATTO currently only allows uploading a `.adat` file. This PR adds allowance for `.bin` files.
